### PR TITLE
📖 [Docs]: Rework README into the standard module landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Base64
 
-Base64 is a lightweight, cross-platform PowerShell module for Base64 conversion and validation. It provides pipeline-friendly commands to
-encode text with `ConvertTo-Base64`, decode it back with `ConvertFrom-Base64`, and verify that a string is valid Base64 with `Test-Base64` —
+Base64 is a lightweight, cross-platform PowerShell module for base64 conversion and validation. It provides pipeline-friendly commands to
+encode text with `ConvertTo-Base64`, decode it back with `ConvertFrom-Base64`, and verify that a string is valid base64 with `Test-Base64` —
 so it drops cleanly into automation workflows.
 
 ## Installation
@@ -15,9 +15,9 @@ Import-Module -Name Base64
 
 ## Usage
 
-### Example: Encode a string to Base64
+### Example: Encode a string to base64
 
-Encode a plain text string into its Base64 representation:
+Encode a plain text string into its base64 representation:
 
 ```powershell
 'Hello World' | ConvertTo-Base64
@@ -29,9 +29,9 @@ Expected output:
 SGVsbG8gV29ybGQ=
 ```
 
-### Example: Decode a Base64 string
+### Example: Decode a base64 string
 
-Convert a Base64 encoded string back to its original human-readable text:
+Convert a base64 encoded string back to its original human-readable text:
 
 ```powershell
 'SGVsbG8gV29ybGQ=' | ConvertFrom-Base64
@@ -43,9 +43,9 @@ Expected output:
 Hello World
 ```
 
-### Example: Validate a Base64 string
+### Example: Validate a base64 string
 
-Check whether a string is a properly formatted Base64 value:
+Check whether a string is a properly formatted base64 value:
 
 ```powershell
 'SGVsbG8gV29ybGQ=' | Test-Base64

--- a/README.md
+++ b/README.md
@@ -1,87 +1,27 @@
 # Base64
 
-base64 is a lightweight PowerShell module that provides a set of functions for encoding and decoding strings using base64 encoding. Designed to be
-simple, efficient, and cross-platform, this module leverages pipeline-friendly commands to integrate seamlessly into your automation workflows.
-
-## Module Features
-
-- `ConvertTo-Base64`: Transforms a plain text string into its base64 encoded equivalent.
-- `ConvertFrom-Base64`: Decodes a base64 encoded string back into a human-readable UTF-8 string.
-- `Test-Base64`: Validates whether a string is a properly formatted base64 encoded string.
-
-Ever questioned whether your base64 data is truly valid? With `Test-Base64`, you can be skeptical and verify it for yourself.
-
-## Prerequisites
-
-This module utilizes the [PSModule framework](https://github.com/PSModule) for building, testing, and publishing. It is compatible with PowerShell
-Core as well as Windows PowerShell—so whether you're on Windows, Linux, or macOS, you're covered.
+Base64 is a PowerShell module for Base64 conversion and validation.
 
 ## Installation
 
-To install the module from the PowerShell Gallery, run the following commands:
+Install the module from the PowerShell Gallery:
 
 ```powershell
 Install-PSResource -Name Base64
 Import-Module -Name Base64
 ```
 
-## Usage
+## Documentation
 
-Here are some example use cases to get you started with the module:
+Documentation is published at [psmodule.io/Base64](https://psmodule.io/Base64/).
 
-### Convert a String to base64
-
-Encode a plain text string into its base64 representation:
+Use PowerShell help and command discovery for module details:
 
 ```powershell
-"Hello World" | ConvertTo-Base64
+Get-Command -Module Base64
+Get-Help <CommandName> -Examples
 ```
-
-**Expected Output:**
-
-```powershell
-SGVsbG8gV29ybGQ=
-```
-
-### Decode a base64 String
-
-Convert a base64 encoded string back to its original human-readable format:
-
-```powershell
-"SGVsbG8gV29ybGQ=" | ConvertFrom-Base64
-```
-
-**Expected Output:**
-
-```powershell
-Hello World
-```
-
-### Validate a base64 String
-
-Check if a string is a valid base64 encoded string:
-
-```powershell
-"SGVsbG8gV29ybGQ=" | Test-Base64
-```
-
-**Expected Output:**
-
-```powershell
-True
-```
-
-Because in automation, a skeptical mind is the best safety net—if it passes the tests, you can trust it (at least until the next edge case shows up).
 
 ## Contributing
 
-Whether you’re a coder or a user with invaluable feedback, your contributions can make this module even better.
-
-### For Users
-
-If you encounter unexpected behavior or think something is missing, please open an issue on [GitHub Issues](https://github.com/yourusername/Base64/issues).
-Your skepticism is welcome—it only makes the project stronger.
-
-### For Developers
-
-Developers, feel free to contribute code improvements or new features. Please read the [Contribution Guidelines](CONTRIBUTING.md) to learn how to get started.
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Base64
 
-Base64 is a PowerShell module for Base64 conversion and validation.
+Base64 is a lightweight, cross-platform PowerShell module for Base64 conversion and validation. It provides pipeline-friendly commands to
+encode text with `ConvertTo-Base64`, decode it back with `ConvertFrom-Base64`, and verify that a string is valid Base64 with `Test-Base64` —
+so it drops cleanly into automation workflows.
 
 ## Installation
 
@@ -11,6 +13,50 @@ Install-PSResource -Name Base64
 Import-Module -Name Base64
 ```
 
+## Usage
+
+### Example: Encode a string to Base64
+
+Encode a plain text string into its Base64 representation:
+
+```powershell
+'Hello World' | ConvertTo-Base64
+```
+
+Expected output:
+
+```text
+SGVsbG8gV29ybGQ=
+```
+
+### Example: Decode a Base64 string
+
+Convert a Base64 encoded string back to its original human-readable text:
+
+```powershell
+'SGVsbG8gV29ybGQ=' | ConvertFrom-Base64
+```
+
+Expected output:
+
+```text
+Hello World
+```
+
+### Example: Validate a Base64 string
+
+Check whether a string is a properly formatted Base64 value:
+
+```powershell
+'SGVsbG8gV29ybGQ=' | Test-Base64
+```
+
+Expected output:
+
+```text
+True
+```
+
 ## Documentation
 
 Documentation is published at [psmodule.io/Base64](https://psmodule.io/Base64/).
@@ -19,9 +65,5 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module Base64
-Get-Help <CommandName> -Examples
+Get-Help -Name ConvertTo-Base64 -Examples
 ```
-
-## Contributing
-
-Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.


### PR DESCRIPTION
## What changed

The `Base64` README is now a proper module landing page: a concise intro, a one-command **Installation** section (`Install-PSResource`), a **Usage** showcase with three real, runnable examples, and a **Documentation** section that points to [psmodule.io/Base64](https://psmodule.io/Base64/).

## User-facing impact

- Anyone landing on the repo or the published docs immediately sees how to install the module and how to encode, decode, and validate Base64 strings with real commands and expected output.
- Restores the three worked examples that were lost in the initial reformat:
  - Encode: `'Hello World' | ConvertTo-Base64`
  - Decode: `'SGVsbG8gV29ybGQ=' | ConvertFrom-Base64`
  - Validate: `'SGVsbG8gV29ybGQ=' | Test-Base64`
- Fixes the command-discovery snippet to use a real command (`Get-Help -Name ConvertTo-Base64 -Examples`) instead of the `<CommandName>` placeholder.

## Notes

- Removes the boilerplate `## Contributing` section per the module landing-page standard.
- Documentation-only change; no module code affected. Markdown validated with the repo's `markdownlint` config.